### PR TITLE
Fix missing WebView provider crash in ForwardingCookieHandler

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -147,7 +147,7 @@ public class ForwardingCookieHandler extends CookieHandler {
             && exception
                 .getClass()
                 .getCanonicalName()
-                .equals("android.webkit.WebViewFactory.MissingWebViewPackageException")) {
+                .contains("MissingWebViewPackageException")) {
           return null;
         } else {
           throw exception;


### PR DESCRIPTION
using this fix 
https://github.com/facebook/react-native/commit/d40cb0e1b0fb233a27b9d476167814d2853acf2a